### PR TITLE
Make bakage.pl an executable

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ default:
 
 build: codegen
     mv bakage.pl.gen bakage.pl
+    chmod +x bakage.pl
 
 codegen:
     #!/bin/sh


### PR DESCRIPTION
Related to #25 (not sure if it closes that though). Continues on #35.

This allows using the file itself as an executable, adds a bit of support for parsing arguments and environment variables (which we will need a lot later), adds the `install` command that does the same thing as `pkg_install/1` but with a friendlier CLI (`pkg_install/1` will probably be deprecated after this), and adds some basic support for configuring colors with environment variables and CLI flags as an example of how to use the system. I've also made a help system that builds upon this, but I'll leave that for another PR.