### PR TITLE
Add help for CLI interface

### DIFF
--- a/bakage.pl
+++ b/bakage.pl
@@ -156,6 +156,47 @@ do_task(install, _) :-
 help_text(root) --> "".
 help_text(install) --> "".
 
+% Uses global color configuration
+ansi(Color) -->
+    {
+        cli_color(CliColor),
+        phrase(ansi(CliColor, Color), Code)
+    },
+    Code.
+
+ansi(off, _) --> "".
+ansi(on, Color) --> ansi_(Color).
+
+% Raw colors
+ansi_(reset) --> "\x1b\[0m".
+ansi_(bold) --> "\x1b\[1m".
+ansi_(red) --> "\x1b\[31m".
+ansi_(green) --> "\x1b\[32m".
+ansi_(yellow) --> "\x1b\[33m".
+ansi_(blue) --> "\x1b\[34m".
+ansi_(magenta) --> "\x1b\[35m".
+ansi_(cyan) --> "\x1b\[36m".
+ansi_(white) --> "\x1b\[37m".
+
+% Color aliases
+ansi_(help_header) --> ansi_(yellow), ansi_(bold).
+ansi_(help_option) --> ansi_(green), ansi_(bold).
+
+% Uses global color configuration
+color_text(Color, Text) -->
+    {
+        cli_color(CliColor),
+        phrase(color_text(CliColor, Color, Text), ColorText)
+    },
+    ColorText.
+
+% Accepts arbitrary grammar rule bodies
+color_text(CliColor, Color, Text) -->
+    { phrase(Text, Text1) },
+    ansi(CliColor, Color),
+    Text1,
+    ansi(CliColor, reset).
+
 % Cleanly pass arguments to a script through environment variables
 run_script_with_args(ScriptName, Args, Success) :-
     maplist(define_script_arg, Args),

--- a/bakage.pl
+++ b/bakage.pl
@@ -153,9 +153,6 @@ do_task(help(CommandPath), _) :-
 do_task(install, _) :-
     pkg_install(_).
 
-help_text(root) --> "".
-help_text(install) --> "".
-
 % Uses global color configuration
 ansi(Color) -->
     {
@@ -196,6 +193,129 @@ color_text(CliColor, Color, Text) -->
     ansi(CliColor, Color),
     Text1,
     ansi(CliColor, reset).
+
+help_text(CommandPath) -->
+    {
+        help_info(CommandPath, Description, Usage, Options, Commands)
+    },
+    help_description(Description),
+    help_usage(Usage),
+    help_option_table("Options", Options),
+    help_option_table("Commands", Commands).
+
+help_info(
+    root,
+    "Bakage: an experimental package manager for Prolog",
+    "bakage [OPTIONS] [COMMAND]",
+    [
+        flag("color", none, "When to use color. Valid options: auto, always, never"),
+        flag("help", "h", "Print help")
+    ],
+    [
+        %command("init", "Create a new project in the current directory"),
+        command("install", "Installs the dependencies of the current package")
+        %command("new", "Create a new project in a new directory"),
+        %command("run", "Runs the current package")
+    ]
+).
+help_info(
+    install,
+    "Install package dependencies",
+    "bakage install [OPTIONS]",
+    [
+        flag("color", none, "When to use color. Valid options: auto, always, never"),
+        flag("help", "h", "Print help")
+    ],
+    []
+).
+
+options_width(Options, OptionWidth) :-
+    options_width(Options, 0, OptionWidth0),
+    OptionWidth is 2 + OptionWidth0 + 2.
+
+options_width([], OptionWidth, OptionWidth).
+options_width([Option|Options], OptionWidth0, OptionWidth) :-
+    option_width(Option, Width),
+    OptionWidth1 is max(OptionWidth0, Width),
+    options_width(Options, OptionWidth1, OptionWidth).
+
+option_width(flag(Long, _, _), Width) :-
+    length(Long, Width0),
+    Width is 4 + Width0.
+option_width(command(Name, _), Width) :-
+    length(Name, Width).
+
+with_tail_newline([]) --> "\n".
+with_tail_newline([H|T]) --> 
+    {
+        Text = [H|T],
+        phrase((..., [Last]), Text),
+        if_(
+            Last = '\n',
+            WithNewline = Text,
+            phrase((Text, "\n"), WithNewline)
+        )
+    },
+    WithNewline.
+
+help_description(Description) -->
+    { phrase(Description, Description1) },
+    with_tail_newline(Description1).
+
+help_usage(Usage) -->
+    { phrase(Usage, Usage1) },
+    "\n",
+    color_text(help_header, "Usage:"),
+    " ",
+    color_text(help_option, Usage1),
+    "\n".
+
+help_option_table(_, []) --> "".
+help_option_table(Name, Options) -->
+    { Options = [_|_] },
+    "\n",
+    color_text(help_header, (Name, ":")), "\n",
+    { options_width(Options, OptionWidth) },
+    help_option_table_(Options, OptionWidth).
+
+help_option_table_([], _) --> "".
+help_option_table_([Option|Options], OptionWidth) -->
+    help_option_table_line(Option, OptionWidth),
+    help_option_table_(Options, OptionWidth).
+
+n_spaces(N) -->
+    {
+        length(Spaces, N),
+        append(Spaces, _, [' '|Spaces])
+    },
+    Spaces.
+
+help_option_table_line(command(Name, Description), OptionWidth) -->
+    { 
+        length(Name, NameLen),
+        PaddingLen is OptionWidth - NameLen - 2
+    },
+    n_spaces(2), color_text(help_option, Name), n_spaces(PaddingLen),
+    with_tail_newline(Description).
+
+help_option_table_line(flag(Long, Short, Description), OptionWidth) -->
+    { 
+        length(Long, LongLen),
+        PaddingLen is OptionWidth - LongLen - 6,
+        if_(
+            Short = none,
+            phrase(n_spaces(4), ShortDesc),
+            phrase(
+                (color_text(help_option, ("-", Short)), ", "),
+                ShortDesc
+            )
+        )
+    },
+    n_spaces(2),
+    ShortDesc,
+    color_text(help_option, ("--", Long)),
+    n_spaces(PaddingLen),
+    with_tail_newline(Description).
 
 % Cleanly pass arguments to a script through environment variables
 run_script_with_args(ScriptName, Args, Success) :-


### PR DESCRIPTION
Continued from #34.

This adds support for getting help from the CLI and its subcommands (currently only `install`). I also added support for terminal colors along the way, because in my experience having colors in tools like this helps tremendously in legibility.

You can configure color with CLI arguments or with the environment variables `NO_COLOR` (de-facto standard for this) and `CLICOLOR_FORCE` (the closest to an de-facto standard for this). Ideally we would also check if stdout is a terminal (instead of a pipe or a file for example), but I have no idea how to do that without completely sacrificing portability (both between Prolog implementations and between different operating systems; I know how to do it for Scryer on Linux with FFI).

Here's a screenshot of how it is right now (colors and formatting inspired by how Jujutsu does it's help): 

![image](https://github.com/user-attachments/assets/9b23def3-6b94-42ae-8911-0b0b4251e81d)

I feel this here was a really good use of DCGs, so I think you may have some interest in it @triska. I would also very much appreciate any ideas for improvement. I know I'm using `(->)/2` in some places where we could probably get away without it. I'm also having the color configuration be global, which I think is probably fine for this use case.